### PR TITLE
Moved Mod Options button to main menu

### DIFF
--- a/Source/SkylineToolkit/PermaMod/MainMenuModification.cs
+++ b/Source/SkylineToolkit/PermaMod/MainMenuModification.cs
@@ -6,22 +6,57 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using UnityEngine;
+using System.Reflection;
+using ColossalFramework;
 
 namespace SkylineToolkit.PermaMod
 {
     public class MainMenuModification : MonoBehaviour
     {
+        MainMenu mainMenu;
+
         void OnEnable()
         {
-            Button btn = new Button("btn_modOptions", "Mod Options", new Vector3(-1.65f, 0.97f), 180, 60);
+            mainMenu = UIView.FindObjectOfType<MainMenu>();
+            UIButton modOptionsButton = CreateMenuItem("ModOptions", "MOD OPTIONS", "Options");
+            modOptionsButton.eventClick += ModOptions;
+        }
 
-            btn.IsActive = true;
-            btn.AbsolutePosition = new Vector3(10f, 10f);
+        private void ModOptions(UIComponent component, UIMouseEventParameter eventParam)
+        {
+            Log.Info("Mod options clicked");
+        }
 
-            btn.Click += (sender, e) =>
+        UIButton CreateMenuItem(string name, string text, string afterName)
+        {
+            GameObject gameObject = UITemplateManager.GetAsGameObject("MainMenuButtonTemplate");
+            gameObject.name = name;
+            UIButton button = (UIButton)mainMenu.component.AttachUIComponent(gameObject);
+            button.text = text;
+
+            UIButton[] buttons = mainMenu.GetComponentsInChildren<UIButton>();
+
+            for (int i = buttons.Count() - 2; i >= 0; i--)
             {
-                Log.Info("Open mod options..." + e.Clicks);
-            };
+                if (buttons[i].name == afterName)
+                    break;
+
+                button.MoveBackward();
+            }
+
+            return button;
+        }
+
+        // TODO: Move this to a command?
+        void ListTemplates()
+        {
+            BindingFlags flags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static;
+            FieldInfo field = typeof(UITemplateManager).GetField("m_Templates", flags);
+            Dictionary<string, UIComponent> templates = (Dictionary<string, UIComponent>)field.GetValue(Singleton<UITemplateManager>.instance);
+            foreach (var key in templates.Keys)
+            {
+                Log.Info(key);
+            }
         }
     }
 }


### PR DESCRIPTION
Had to use an assembly decompiler to figure out some of this stuff. Most methods should probably be moved to another class to make more sense, but I just kept my code in one class for now.

One bug I have noticed is when building the project with C:S running, the mod does get called again, but only with the old code. So a new button does get added (which leads to the button appearing multiple times) but any changes made in the code will not apply to it.
